### PR TITLE
Add PositionEmbedding module with tests

### DIFF
--- a/nano_llm/position_embeddings.py
+++ b/nano_llm/position_embeddings.py
@@ -8,4 +8,7 @@ class PositionEmbedding(nn.Module):
 
     def forward(self, x):
         seq_len = x.size(0)
+        if seq_len > self.weight.size(0):
+            raise IndexError(f"""Sequence length {seq_len}
+                             exceeds maximum {self.weight.size(0)}""")
         return self.weight[:seq_len, :]

--- a/nano_llm/position_embeddings.py
+++ b/nano_llm/position_embeddings.py
@@ -1,0 +1,11 @@
+import torch
+import torch.nn as nn
+
+class PositionEmbedding(nn.Module):
+    def __init__(self, max_len: int, d_model: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(max_len, d_model) * (d_model ** -0.5))
+
+    def forward(self, x):
+        seq_len = x.size(0)
+        return self.weight[:seq_len, :]

--- a/nano_llm/position_embeddings.py
+++ b/nano_llm/position_embeddings.py
@@ -1,12 +1,48 @@
+"""
+Positional embeddings provide the model with information about the order of
+the tokens. Unlike token embeddings, which map discrete token IDs to
+learnable vectors, positional embeddings assing each position in the
+sequence a learnable representation.
+
+This module implements a simple learned position embedding matrix of
+shape [], where each row corresponds to the embedding of a
+position index from 0 to max_len - 1.
+
+The forward pass simply indexes into this matrix using the positions
+provided. Forward does not perform any computation besides lookup.
+"""
+
 import torch
 import torch.nn as nn
 
 class PositionEmbedding(nn.Module):
+    """
+    Learnable positional embedding layer.
+
+    Args:
+        max_len (int): Maximum sequence length supported.
+        d_model (int): Dimensionality of each positional vector.
+
+    Shape:
+        - Input: LongTensor of shape (...), containing position indices
+            in the range [0, max_len - 1]
+        - Output: Tensor of shape (..., d_model), where each position is
+            mapped to its corresponding embedding vector.
+    """
     def __init__(self, max_len: int, d_model: int):
         super().__init__()
         self.weight = nn.Parameter(torch.randn(max_len, d_model) * (d_model ** -0.5))
 
     def forward(self, x):
+        """
+        Retrieve positional embeddings for the given indices.
+
+        Args:
+            x (Tensor): A tensor of position indices.
+
+        Returns:
+            Tensor: Positional embeddings correspondign to each index.
+        """
         seq_len = x.size(0)
         if seq_len > self.weight.size(0):
             raise IndexError(f"""Sequence length {seq_len}

--- a/tests/test_position_embeddings.py
+++ b/tests/test_position_embeddings.py
@@ -1,0 +1,29 @@
+import torch
+import pytest
+from nano_llm.position_embeddings import PositionEmbedding
+
+def test_embedding_shape():
+    max_len, d_model = 20, 16
+    emb = PositionEmbedding(max_len, d_model)
+    x = torch.zeros(10)
+    out = emb(x)
+    assert out.shape == (10, d_model)
+
+def test_embedding_grad():
+    max_len, d_model = 20, 16
+    emb = PositionEmbedding(max_len, d_model)
+    x = torch.zeros(5)
+
+    out = emb(x).sum()
+    out.backward()
+
+    assert emb.weight.grad is not None
+    assert emb.weight.grad.shape == emb.weight.shape
+
+def test_embedding_out_of_range():
+    max_len, d_model = 10, 16
+    emb = PositionEmbedding(max_len, d_model)
+    x = torch.zeros(12)
+
+    with pytest.raises(IndexError):
+        emb(x)


### PR DESCRIPTION
## What
Implements the PositionEmbedding module with:
- Learneable positional embeddings
- Sequence length validation
- Unit tests including out-of-range behaviour

## Why
This is the first building block for the transformer architecture.
Explicit validation prevents silent errors when sequence length exceeds `max_len`.

## How to test
Locally:
```bash
pytest -q
ruff check .
mypy .
```

Docker:
```bash
docker compose up --build
```