### PR TITLE
Add TransformerBlock module

### DIFF
--- a/nano_llm/attention.py
+++ b/nano_llm/attention.py
@@ -95,7 +95,7 @@ class MultiHeadAttention(nn.Module):
         else:
             mask = mask.bool()
 
-        attn_out = self.scaled_dot_product_attention(q, k, v, mask)
+        attn_out = scaled_dot_product_attention(q, k, v, mask)
 
         #concatenate heads: (B, num_heads, T, d_head) -> (B, T, d_model)
         B, num_heads, T, d_head = attn_out.shape

--- a/nano_llm/transformer_block.py
+++ b/nano_llm/transformer_block.py
@@ -1,0 +1,57 @@
+"""
+Single transformer block with self-attention and feedforward network.
+"""
+
+import torch
+import torch.nn as nn
+from typing import Optional
+from nano_llm.attention import MultiHeadAttention
+
+class TransformerBlock(nn.Module):
+    def __init__(self, d_model:int, num_heads:int, ff_hidden:int, dropout:float=0.0):
+        """
+        Features:
+            - Multi-head self-attention with causal masking.
+            - Residual connection with LayerNorm.
+            - Feedforward network with 2 linear layers and ReLU.
+            - Optional dropout on attention and feedforward.
+
+        Args:
+            d_model (int): Input/output dimension.
+            num_heads (int): Number of attention heads.
+            ff_hidden (int): Hidden dimension of feedforward network.
+            dropout (float): Dropout probability for attention and feedforward.
+        """
+        super().__init__()
+
+        self.mha = MultiHeadAttention(d_model=d_model,
+                                      num_heads=num_heads,
+                                      dropout=dropout)
+        self.ln1 = nn.LayerNorm(d_model)
+
+        self.ff = nn.Sequential(
+            nn.Linear(d_model, ff_hidden),
+            nn.ReLU(),
+            nn.Linear(ff_hidden, d_model)
+        )
+        self.ln2 = nn.LayerNorm(d_model)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+        """
+        Forward pass for a single Transformer block.
+
+        Args:
+            x (Tensor): Input embeddings of shape (B, T, d_model)
+            padding_mask (BoolTensor, optional): Mask for padded tokens, shape (B, T)
+
+        Returns:
+            Tensor: Output embeddings, shape (B, T, d_model)
+        """
+        attn_out = self.mha(x, padding_mask=padding_mask)
+        x = self.ln1(x + self.dropout(attn_out))
+
+        ff_out = self.ff(x)
+        x = self.ln1(x + self.dropout(ff_out))
+
+        return x

--- a/tests/test_transformer_block.py
+++ b/tests/test_transformer_block.py
@@ -1,0 +1,73 @@
+import torch
+from nano_llm.transformer_block import TransformerBlock
+
+def test_transformer_block_output_shape():
+    B, T, D = 2, 3, 32
+    x = torch.randn(B, T, D)
+    block = TransformerBlock(d_model=D, num_heads=4, ff_hidden=64)
+    out = block(x)
+    assert out.shape == (B, T, D)
+
+def test_transformer_block_residual():
+    x = torch.randn(2, 3, 32)
+    block = TransformerBlock(d_model=32, num_heads=4, ff_hidden=64)
+    out = block(x)
+    assert not torch.allclose(out, x)
+
+def test_transformer_block_is_causal():
+    torch.manual_seed(0)
+
+    B, T, D = 1, 4, 16
+    x = torch.randn(B, T, D)
+
+    block = TransformerBlock(d_model=D, num_heads=4, ff_hidden=32)
+    block.eval()
+
+    out1 = block(x)
+
+    x_future_changed = x.clone()
+    x_future_changed[:, -1, :] += 10.0
+
+    out2 = block(x_future_changed)
+
+    assert torch.allclose(out1[:, :-1], out2[:, :-1], atol=1e-5)
+
+def test_transformer_block_padding_mask():
+    torch.manual_seed(0)
+
+    B, T, D = 2, 4, 16
+    x = torch.randn(B, T, D)
+
+    padding_mask = torch.tensor([
+        [1, 1, 1, 0],
+        [1, 1, 0, 0],
+    ], dtype=torch.bool)
+
+    block = TransformerBlock(d_model=D, num_heads=4, ff_hidden=32)
+    block.eval()
+
+    out = block(x, padding_mask=padding_mask)
+
+    assert out.shape == (B, T, D)
+
+def test_transformer_block_deterministic_eval():
+    torch.manual_seed(0)
+
+    x = torch.randn(1, 3, 16)
+    block = TransformerBlock(d_model=16, num_heads=4, ff_hidden=32, dropout=0.1)
+    block.eval()
+
+    out1 = block(x)
+    out2 = block(x)
+
+    assert torch.allclose(out1, out2)
+
+def test_transformer_block_backward():
+    x = torch.randn(2, 3, 16, requires_grad=True)
+    block = TransformerBlock(d_model=16, num_heads=4, ff_hidden=32)
+
+    out = block(x)
+    loss = out.sum()
+    loss.backward()
+
+    assert x.grad is not None


### PR DESCRIPTION
## What 
Implements a standard Transformer block with:
- Multi-head self-attention
- Feed-forward network
- Residual connections and layer normalization
- Dropout support

Include unit tests.

## Why
This block is the core building unit of the Transformer architecture. Having it isolated enables composing high-level models without hidden assumptions.

## How to test
Locally:
```bash
pytest -q
ruff check .
mypy.
```

Docker:
```bash
docker compose up --build
```