### PR TITLE
Add MiniTransformer model

### DIFF
--- a/nano_llm/mini_transformer.py
+++ b/nano_llm/mini_transformer.py
@@ -1,0 +1,54 @@
+import torch
+import torch.nn as nn
+from nano_llm.embeddings import TokenEmbedding
+from nano_llm.position_embeddings import PositionEmbedding
+from nano_llm.transformer_block import TransformerBlock
+
+class MiniTransformer(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        d_model: int,
+        num_heads: int,
+        ff_hidden: int,
+        num_layers: int,
+        max_len: int,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+
+        self.token_emb = TokenEmbedding(vocab_size, d_model)
+        self.pos_emb = PositionEmbedding(max_len, d_model)
+
+        self.blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    d_model=d_model,
+                    num_heads=num_heads,
+                    ff_hidden=ff_hidden,
+                    dropout=dropout,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+        self.ln_f = nn.LayerNorm(d_model)
+        self.head = nn.Linear(d_model, vocab_size, bias=False)
+
+    def forward(self, x: torch.Tensor):
+        B, T = x.shape
+        device = x.device
+
+        tok_emb = self.token_emb(x)
+        pos_ids = torch.arange(T, device=device)
+        pos_emb = self.pos_emb(pos_ids)
+
+        h = tok_emb + pos_emb
+
+        for block in self.blocks:
+            h = block(h)
+
+        h = self.ln_f(h)
+        logits = self.head(h)
+
+        return logits

--- a/nano_llm/mini_transformer.py
+++ b/nano_llm/mini_transformer.py
@@ -5,6 +5,16 @@ from nano_llm.position_embeddings import PositionEmbedding
 from nano_llm.transformer_block import TransformerBlock
 
 class MiniTransformer(nn.Module):
+    """
+    Decoder-only transformer model.
+
+    This module implements a minimal Transformer model composed of token and
+    positional embeddings, a stack of Transformer blocks with causal
+    self-attention, and a final linear projection to vocab logits.
+
+    The model operates on token indices and returns unnormalized
+    logits for each position in the input sequence.
+    """
     def __init__(
         self,
         vocab_size: int,
@@ -36,6 +46,15 @@ class MiniTransformer(nn.Module):
         self.head = nn.Linear(d_model, vocab_size, bias=False)
 
     def forward(self, x: torch.Tensor):
+        """
+        Forward pass of the Transformer.
+
+        Args:
+            x (LongTensor): Input token indices of shape (B, T).
+
+        Returns:
+            Tensor: Logits of shape (B, T, vocab_size)
+        """
         B, T = x.shape
         device = x.device
 

--- a/tests/test_mini_transformer.py
+++ b/tests/test_mini_transformer.py
@@ -1,0 +1,62 @@
+import torch
+from nano_llm.mini_transformer import MiniTransformer
+
+def test_mini_transformer_output_shape():
+    B, T = 2, 4
+    vocab_size = 100
+    d_model = 32
+
+    x = torch.randint(0, vocab_size, (B, T))
+    model = MiniTransformer(
+        vocab_size=vocab_size,
+        d_model=d_model,
+        num_heads=4,
+        ff_hidden=64,
+        num_layers=2,
+        max_len=16,
+    )
+
+    out = model(x)
+    assert out.shape == (B, T, vocab_size)
+
+def test_mini_transformer_causal_consistency():
+    torch.manual_seed(0)
+
+    vocab_size = 50
+    x1 = torch.tensor([[1, 2, 3]])
+    x2 = torch.tensor([[1, 2, 9]])
+
+    model = MiniTransformer(
+        vocab_size=vocab_size,
+        d_model=32,
+        num_heads=4,
+        ff_hidden=64,
+        num_layers=1,
+        max_len=8,
+    )
+    model.eval()
+
+    out1 = model(x1)
+    out2 = model(x2)
+
+    assert torch.allclose(out1[:,:2], out2[:, :2], atol=1e-6)
+
+def test_mini_transformer_deterministic_eval():
+    torch.manual_seed(0)
+
+    x = torch.randint(0, 20, (1, 5))
+    model = MiniTransformer(
+        vocab_size=20,
+        d_model=16,
+        num_heads=4,
+        ff_hidden=32,
+        num_layers=2,
+        max_len=10,
+        dropout=0.1,
+    )
+    model.eval()
+
+    out1 = model(x)
+    out2 = model(x)
+
+    assert torch.allclose(out1, out2)


### PR DESCRIPTION
## What
Implements a minimal decoder-only transformer model composed of:
- Token and positional embeddings
- A stack of Transformer blocks with causal self-attention
- Final layer normalization and linear projection to vocabulary logits

## Why
This module completes the core model architecture, enabling end-to-end forward passes and future autoregressive generation.

## How to test:
Locally:
```bash
pytest -q
ruff check .
mypy .
```

Docker:
````bash
docker compose up --build
```