### PR TITLE
Add autoregressive generation

### DIFF
--- a/nano_llm/generation.py
+++ b/nano_llm/generation.py
@@ -1,0 +1,27 @@
+from nano_llm.mini_transformer import MiniTransformer
+import torch
+
+def generate(
+        model: MiniTransformer,
+        input_ids: torch.Tensor,
+        max_new_tokens: int,
+        temperature: float = 1.0,
+):
+    model.eval()
+    generated = input_ids.clone()
+
+    with torch.no_grad():
+        for _ in range(max_new_tokens):
+            logits = model(generated)
+            next_token_logits = logits[:, -1, :]
+
+            if temperature == 0.0:
+                next_token = torch.argmax(next_token_logits, dim=-1, keepdim=True)
+            else:
+                scaled_logits = next_token_logits / temperature
+                probs = torch.softmax(scaled_logits, dim=-1)
+                next_token = torch.multinomial(probs, num_samples=1)
+
+            generated = torch.cat([generated, next_token], dim=1)
+
+    return generated

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,57 @@
+from nano_llm.generation import generate
+from nano_llm.mini_transformer import MiniTransformer
+import torch
+
+def test_generate_shape():
+    vocab_size = 20
+    model = MiniTransformer(
+        vocab_size=vocab_size,
+        d_model=16,
+        num_heads=4,
+        ff_hidden=32,
+        num_layers=1,
+        max_len=10
+    )
+    model.eval()
+
+    x = torch.randint(0, vocab_size, (1, 3))
+    out = generate(model, x, max_new_tokens=5)
+
+    assert out.shape == (1, 8)
+
+def test_generate_deterministic_greedy():
+    torch.manual_seed(0)
+
+    vocab_size = 10
+    model = MiniTransformer(
+        vocab_size=vocab_size,
+        d_model=16,
+        num_heads=4,
+        ff_hidden=32,
+        num_layers=1,
+        max_len=10,
+    )
+    model.eval()
+
+    x = torch.randint(0, vocab_size, (1, 3))
+    out1 = generate(model, x, max_new_tokens=3, temperature=0.0)
+    out2 = generate(model, x, max_new_tokens=3, temperature=0.0)
+
+    assert torch.equal(out1, out2)
+
+def test_generate_prefix_preserved():
+    vocab_size = 15
+    model = MiniTransformer(
+        vocab_size=vocab_size,
+        d_model=16,
+        num_heads=4,
+        ff_hidden=32,
+        num_layers=1,
+        max_len=10,
+    )
+    model.eval()
+
+    x = torch.tensor([[1, 2, 3]])
+    out = generate(model, x, max_new_tokens=4)
+
+    assert torch.equal(out[:, :3], x)


### PR DESCRIPTION
## What
Implements a simple autoregressive token generation function for the decoder-only transformer.
- Supports greedy decodign for a given input sequence.

## Why
Establishes a baseline for sequence generation.