### PR TITLE
Add KV-cache support and advanced sampling for autoregressive generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,63 @@
-# nano-llm
+# Nano LLM - Decoder-Only
+This repository implements a minimal decoder-only Transformer, inspired by GPT architectures.
 
-This projects aims to implemente the core concepts of a Transformer from scratch to deepen understanding of modern LLM architectures.
+The goal of this project is to understand and implement the core concepts of a modern LLM from first priciples, without relying on high-level libraries.
 
 ## Objectives
-* Build embeddings, positional embeddings, attention, multi-head attention, feed-forward, decoder.
-* Train a minimal GPT-style model on small dataset.
-* Document each module clearly.
-* Provide tests and experiments notebooks.
 
+### 1. Embeddings
+- [x] **TokenEmbedding**
+  - Learnable lookup table `(vocab_size, d_model)`
+  - Forward = direct indexing
+  - Updated via backprop only
+- [x] **PositionEmbedding**
+  - Learned positional embeddings
+  - Fixed max sequence length
+  - Added to token embeddings
+
+### 2. Attention
+- [x] **Scaled Dot-Product Attention**
+  - Proper scaling by `sqrt(d_k)`
+  - Softmax + optional dropout
+  - Boolean masking support
+- [x] **Multi-Head Causal Self-Attention**
+  - Q/K/V projections
+  - Multi-head split
+  - Causal (lower-triangular) mask
+  - Optional padding mask
+  - KV-cache support
+
+### 3. Transformer Block
+- [x] **TransformerBlock**
+  - Causal multi-head self-attention
+  - Residual connections
+  - Layer normalization
+  - Feedforward network (2-layer MLP with ReLU)
+  - Dropout
+
+### 4. Model
+- [x] **MiniTransformer**
+  - Decoder-only
+  - Stack of configurable blocks
+  - Token + positional embeddings
+  - Final projection to vocab
+  - KV-cache per layer
+
+### 5. Text Generation
+- [x] **Autoregressive generation**
+  - Token-by-token decoding
+  - KV-cache reuse
+  - Temperature sampling
+  - Top-k sampling
+  - Top-p sampling
+  - Greedy decoding (`temperature=0`)
+
+### 6. Training
+- [ ] Training loop
+- [ ] Cross-entropy loss with shift (teacher forcing)
+- [ ] Padding handling (`ignore_index`)
+- [ ] Optimizer (AdamW)
+- [ ] Gradient clipping
+- [ ] Learning rate scheduling
 
 

--- a/nano_llm/attention.py
+++ b/nano_llm/attention.py
@@ -9,7 +9,7 @@ heads, and then combined via scaled dot-product attention.
 import torch
 import torch.nn as nn
 import math
-from typing import Optional
+from typing import Optional, Tuple
 
 
 class MultiHeadAttention(nn.Module):
@@ -73,29 +73,52 @@ class MultiHeadAttention(nn.Module):
 
         return q, k, v
 
-    def forward(self, x: torch.Tensor, padding_mask: Optional[torch.Tensor]=None):
+    def forward(self,
+                x: torch.Tensor,
+                padding_mask: Optional[torch.Tensor]=None,
+                past_kv: Optional[Tuple[torch.Tensor, torch.Tensor]]=None):
         """
         Compute multi-head self-attention.
 
         Args:
             x (Tensor): Input embedding of shape (B, T, D)
             padding_mask (BoolTensor, optional): Mask for padded tokens, shape (B, T)
+            past_kv (Tensor): tuple of (k_prev, v_prev) each
+                (B, num_heads, T_prev, d_head)
 
         Returns:
             Tensor: Output embeddings after self-attention, shape (B, T, D)
+            present_kv: (k, v) including previous
         """
         B, T, D = x.shape
 
         q, k, v = self.project_qkv(x)
 
-        mask = torch.tril(torch.ones(T, T, device=x.device)).unsqueeze(0).unsqueeze(0)
-        if padding_mask is not None:
-            padding_mask = padding_mask[:, None, None, :]
-            mask = mask.bool() & padding_mask
-        else:
-            mask = mask.bool()
+        if past_kv is not None:
+            k_prev, v_prev = past_kv
+            k = torch.cat([k_prev, k], dim=2)
+            v = torch.cat([v_prev, v], dim=2)
+        present_kv = (k, v)
 
-        attn_out = scaled_dot_product_attention(q, k, v, mask)
+        total_len = k.size(2)
+        mask = torch.tril(
+            torch.ones(T, total_len, device=x.device)
+        ).unsqueeze(0).unsqueeze(0).bool()
+
+        if padding_mask is not None:
+            # Extend padding mask for past tokens
+            if past_kv is not None:
+                pad = torch.ones(
+                    B,
+                    past_kv[0].size(2),
+                    device=x.device,
+                    dtype=torch.bool
+                )
+                padding_mask = torch.cat([pad, padding_mask], dim=1)
+            padding_mask = padding_mask[:, None, None, :]
+            mask = mask & padding_mask
+
+        attn_out = scaled_dot_product_attention(q, k, v, mask, self.attn_dropout)
 
         #concatenate heads: (B, num_heads, T, d_head) -> (B, T, d_model)
         B, num_heads, T, d_head = attn_out.shape
@@ -104,7 +127,7 @@ class MultiHeadAttention(nn.Module):
         # output projection
         out = self.out_proj(attn_out)
 
-        return out
+        return out, present_kv
 
 def scaled_dot_product_attention(q: torch.Tensor,
                                  k: torch.Tensor,

--- a/nano_llm/generation.py
+++ b/nano_llm/generation.py
@@ -1,25 +1,72 @@
 from nano_llm.mini_transformer import MiniTransformer
 import torch
+from typing import Optional
 
 def generate(
         model: MiniTransformer,
         input_ids: torch.Tensor,
         max_new_tokens: int,
         temperature: float = 1.0,
+        top_k: Optional[int] = None,
+        top_p: Optional[float] = None,
 ):
+    """
+    Generate tokens autoregressively using the MiniTransformer with kv-cache.
+
+    Args:
+        model: MiniTransformer model
+        input_ids: (B, T) starting tokens
+        max_new_tokens: number of tokens to generate
+        temperature: sampling temperature (0 = greedy)
+        top_k: optionally apply top-k filtering
+        top_p: optionally apply top-p (nucleus) filtering
+
+    Returns:
+        generated: (B, T + max_new_tokens) token indices
+    """
+
     model.eval()
     generated = input_ids.clone()
+    past_kvs = None
 
     with torch.no_grad():
         for _ in range(max_new_tokens):
-            logits = model(generated)
+            # Model forward with kv cache
+            logits, past_kvs = model(generated[:, -1:], past_kvs=past_kvs)
+            # Take logits of the last token
             next_token_logits = logits[:, -1, :]
 
+            # Apply temperature
             if temperature == 0.0:
                 next_token = torch.argmax(next_token_logits, dim=-1, keepdim=True)
             else:
                 scaled_logits = next_token_logits / temperature
                 probs = torch.softmax(scaled_logits, dim=-1)
+
+                # Apply top-k
+                if top_k is not None:
+                    topk_vals, topk_ids = torch.topk(probs, top_k, dim=-1)
+                    probs = torch.zeros_like(probs).scatter_(-1, topk_ids, topk_vals)
+                    probs = probs / probs.sum(dim=-1, keepdim=True)
+
+                if top_p is not None:
+                    sorted_probs, sorted_idx = torch.sort(
+                        probs,
+                        descending=True,
+                        dim=-1
+                    )
+                    cum_probs = torch.cumsum(sorted_probs, dim=-1)
+                    mask = cum_probs > top_p
+                    mask[..., 1:] = mask[..., : -1].clone()
+                    mask[..., 0] = False
+                    sorted_probs[mask] = 0.0
+                    probs = torch.zeros_like(probs).scatter_(
+                        -1,
+                        sorted_idx,
+                        sorted_probs
+                    )
+                    probs = probs / probs.sum(dim=-1, keepdim=True)
+
                 next_token = torch.multinomial(probs, num_samples=1)
 
             generated = torch.cat([generated, next_token], dim=1)

--- a/nano_llm/mini_transformer.py
+++ b/nano_llm/mini_transformer.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+from typing import Optional, List, Tuple
 from nano_llm.embeddings import TokenEmbedding
 from nano_llm.position_embeddings import PositionEmbedding
 from nano_llm.transformer_block import TransformerBlock
@@ -45,15 +46,23 @@ class MiniTransformer(nn.Module):
         self.ln_f = nn.LayerNorm(d_model)
         self.head = nn.Linear(d_model, vocab_size, bias=False)
 
-    def forward(self, x: torch.Tensor):
+    def forward(self,
+                x: torch.Tensor,
+                padding_mask: Optional[torch.Tensor] = None,
+                past_kvs: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None
+    ):
         """
         Forward pass of the Transformer.
 
         Args:
             x (LongTensor): Input token indices of shape (B, T).
+            padding_mask (BoolTensor, optional): Mask for padded tokens, shape (B, T)
+            past_kvs (List, optional): list of (k, v) tuples from previous steps,
+                one per block
 
         Returns:
             Tensor: Logits of shape (B, T, vocab_size)
+            new_past_kvs: updated past key/values for each block
         """
         B, T = x.shape
         device = x.device
@@ -64,10 +73,13 @@ class MiniTransformer(nn.Module):
 
         h = tok_emb + pos_emb
 
-        for block in self.blocks:
-            h = block(h)
+        new_past_kvs = []
+        for i, block in enumerate(self.blocks):
+            block_past_kv = past_kvs[i] if past_kvs is not None else None
+            h, present_kv = block(h, padding_mask=padding_mask, past_kv=block_past_kv)
+            new_past_kvs.append(present_kv)
 
         h = self.ln_f(h)
         logits = self.head(h)
 
-        return logits
+        return logits, new_past_kvs

--- a/nano_llm/transformer_block.py
+++ b/nano_llm/transformer_block.py
@@ -4,7 +4,7 @@ Single transformer block with self-attention and feedforward network.
 
 import torch
 import torch.nn as nn
-from typing import Optional
+from typing import Optional, Tuple
 from nano_llm.attention import MultiHeadAttention
 
 class TransformerBlock(nn.Module):
@@ -37,7 +37,10 @@ class TransformerBlock(nn.Module):
         self.ln2 = nn.LayerNorm(d_model)
         self.dropout = nn.Dropout(dropout)
 
-    def forward(self, x: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def forward(self,
+                x: torch.Tensor,
+                padding_mask: Optional[torch.Tensor] = None,
+                past_kv: Optional[Tuple[torch.Tensor, torch.Tensor]]=None):
         """
         Forward pass for a single Transformer block.
 
@@ -48,10 +51,10 @@ class TransformerBlock(nn.Module):
         Returns:
             Tensor: Output embeddings, shape (B, T, d_model)
         """
-        attn_out = self.mha(x, padding_mask=padding_mask)
-        x = self.ln1(x + self.dropout(attn_out))
+        attn_out, present_kv = self.mha(x, padding_mask=padding_mask, past_kv=past_kv)
+        h = self.ln1(x + self.dropout(attn_out))
 
-        ff_out = self.ff(x)
-        x = self.ln1(x + self.dropout(ff_out))
+        ff_out = self.ff(h)
+        x = self.ln2(h + self.dropout(ff_out))
 
-        return x
+        return x, present_kv

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -55,3 +55,19 @@ def test_generate_prefix_preserved():
     out = generate(model, x, max_new_tokens=4)
 
     assert torch.equal(out[:, :3], x)
+
+def test_generation_sampling_topk_topp():
+    B, T, D = 1, 2, 16
+    vocab_size = 20
+    model = MiniTransformer(
+        d_model=D,
+        num_heads=2,
+        ff_hidden=32,
+        vocab_size=vocab_size,
+        num_layers=1,
+        max_len=10
+    )
+    x = torch.randint(0, vocab_size, (B, T))
+    out = generate(model, x, max_new_tokens=5, temperature=1.0, top_k=5, top_p=0.9)
+    assert out.shape == (B, T + 5)
+

--- a/tests/test_mini_transformer.py
+++ b/tests/test_mini_transformer.py
@@ -16,7 +16,7 @@ def test_mini_transformer_output_shape():
         max_len=16,
     )
 
-    out = model(x)
+    out, _ = model(x)
     assert out.shape == (B, T, vocab_size)
 
 def test_mini_transformer_causal_consistency():
@@ -36,8 +36,8 @@ def test_mini_transformer_causal_consistency():
     )
     model.eval()
 
-    out1 = model(x1)
-    out2 = model(x2)
+    out1, _ = model(x1)
+    out2, _ = model(x2)
 
     assert torch.allclose(out1[:,:2], out2[:, :2], atol=1e-6)
 
@@ -56,7 +56,7 @@ def test_mini_transformer_deterministic_eval():
     )
     model.eval()
 
-    out1 = model(x)
-    out2 = model(x)
+    out1, _ = model(x)
+    out2, _ = model(x)
 
     assert torch.allclose(out1, out2)

--- a/tests/test_transformer_block.py
+++ b/tests/test_transformer_block.py
@@ -5,13 +5,13 @@ def test_transformer_block_output_shape():
     B, T, D = 2, 3, 32
     x = torch.randn(B, T, D)
     block = TransformerBlock(d_model=D, num_heads=4, ff_hidden=64)
-    out = block(x)
+    out, _ = block(x)
     assert out.shape == (B, T, D)
 
 def test_transformer_block_residual():
     x = torch.randn(2, 3, 32)
     block = TransformerBlock(d_model=32, num_heads=4, ff_hidden=64)
-    out = block(x)
+    out, _ = block(x)
     assert not torch.allclose(out, x)
 
 def test_transformer_block_is_causal():
@@ -23,12 +23,12 @@ def test_transformer_block_is_causal():
     block = TransformerBlock(d_model=D, num_heads=4, ff_hidden=32)
     block.eval()
 
-    out1 = block(x)
+    out1, _ = block(x)
 
     x_future_changed = x.clone()
     x_future_changed[:, -1, :] += 10.0
 
-    out2 = block(x_future_changed)
+    out2, _ = block(x_future_changed)
 
     assert torch.allclose(out1[:, :-1], out2[:, :-1], atol=1e-5)
 
@@ -46,7 +46,7 @@ def test_transformer_block_padding_mask():
     block = TransformerBlock(d_model=D, num_heads=4, ff_hidden=32)
     block.eval()
 
-    out = block(x, padding_mask=padding_mask)
+    out, _ = block(x, padding_mask=padding_mask)
 
     assert out.shape == (B, T, D)
 
@@ -57,8 +57,8 @@ def test_transformer_block_deterministic_eval():
     block = TransformerBlock(d_model=16, num_heads=4, ff_hidden=32, dropout=0.1)
     block.eval()
 
-    out1 = block(x)
-    out2 = block(x)
+    out1, _ = block(x)
+    out2, _ = block(x)
 
     assert torch.allclose(out1, out2)
 
@@ -66,7 +66,7 @@ def test_transformer_block_backward():
     x = torch.randn(2, 3, 16, requires_grad=True)
     block = TransformerBlock(d_model=16, num_heads=4, ff_hidden=32)
 
-    out = block(x)
+    out, _ = block(x)
     loss = out.sum()
     loss.backward()
 


### PR DESCRIPTION
## What
Added KV-cache support across the decoder stack:
- MultiHeadAttention
- TransformerBlock
- MiniTransformer

Also updated causal self-attention to concatenate past and current keys/values during autoregressive decoding.

## Why
KV-cache is a core optimization used in modern decoder-only LLMs, allowing keys and values from previous tokens to be reused and reducing per-token generation cost.

## How to test
Locally
```bash
pytest -q
ruff check .
mypy .
```

Docker
```bash
docker compose up --build
```